### PR TITLE
Add multi-select bulk actions, rename rules, and ZIP download

### DIFF
--- a/packages/dashboard/src/components/files/CreateFolder.vue
+++ b/packages/dashboard/src/components/files/CreateFolder.vue
@@ -11,7 +11,7 @@
         <q-card-section class="q-pt-none">
           <q-input dense v-model="newFolderName" autofocus
                    lazy-rules
-                   :rules="[ val => val && val.length > 0 || 'Please type something']" />
+                   :rules="folderNameRules" />
         </q-card-section>
 
         <q-card-actions align="right" class="text-primary">
@@ -68,6 +68,18 @@ export default defineComponent({
 				return decode(this.$route.params.folder);
 			}
 			return "";
+		},
+		folderNameRules: function () {
+			const rules = [
+				(val) => (val && val.length > 0) || "Please type something",
+			];
+			if (this.mainStore.noSpacesInNames) {
+				rules.push(
+					(val) =>
+						!val.includes(" ") || "Spaces are not allowed in folder names",
+				);
+			}
+			return rules;
 		},
 	},
 	setup() {

--- a/packages/dashboard/src/components/files/FileOptions.vue
+++ b/packages/dashboard/src/components/files/FileOptions.vue
@@ -488,6 +488,10 @@ export default defineComponent({
 				return "Name can't contain /";
 			}
 
+			if (this.mainStore.noSpacesInNames && value.includes(" ")) {
+				return "Spaces are not allowed in names";
+			}
+
 			const duplicate = this.existingItems.some((item) => {
 				if (!item || item.key === this.row.key) {
 					return false;

--- a/packages/dashboard/src/pages/SettingsPage.vue
+++ b/packages/dashboard/src/pages/SettingsPage.vue
@@ -87,6 +87,29 @@
 
       <q-card class="q-mb-lg">
         <q-card-section>
+          <div class="text-h6">File Naming</div>
+          <div class="text-caption text-grey-7">
+            Configure rules for file and folder names
+          </div>
+        </q-card-section>
+
+        <q-card-section>
+          <q-toggle
+            v-model="mainStore.noSpacesInNames"
+            label="Disallow spaces in names"
+            color="primary"
+            @update:model-value="mainStore.setNoSpacesSetting"
+          />
+
+          <div class="q-mt-md text-caption text-grey-7">
+            When enabled, spaces in uploaded file names will be automatically replaced with underscores.
+            Renaming files and creating folders will also validate against spaces.
+          </div>
+        </q-card-section>
+      </q-card>
+
+      <q-card class="q-mb-lg">
+        <q-card-section>
           <div class="text-h6">Cache Management</div>
           <div class="text-caption text-grey-7">
             Manage cache versions for your files

--- a/packages/dashboard/src/stores/main-store.js
+++ b/packages/dashboard/src/stores/main-store.js
@@ -78,8 +78,6 @@ export const useMainStore = defineStore("main", {
 					error: e.message || "Failed to save settings",
 				};
 			}
-			// Also load no-spaces setting
-			this.loadNoSpacesSetting();
 		},
 		loadNoSpacesSetting() {
 			const stored = localStorage.getItem("r2explorer-no-spaces");
@@ -107,6 +105,7 @@ export const useMainStore = defineStore("main", {
 				this.buckets = response.data.buckets;
 
 				await this.loadDirectLinkSettings();
+				this.loadNoSpacesSetting();
 
 				const url = new URL(window.location.href);
 				if (url.searchParams.get("next")) {

--- a/packages/dashboard/src/stores/main-store.js
+++ b/packages/dashboard/src/stores/main-store.js
@@ -19,6 +19,9 @@ export const useMainStore = defineStore("main", {
 			baseUrl: "",
 			singleBucketMode: false,
 		},
+
+		// File naming settings
+		noSpacesInNames: true, // default ON
 	}),
 	getters: {
 		serverUrl() {
@@ -43,6 +46,18 @@ export const useMainStore = defineStore("main", {
 					console.error("Failed to load direct link settings:", e);
 				}
 			}
+			// Also load no-spaces setting
+			this.loadNoSpacesSetting();
+		},
+		loadNoSpacesSetting() {
+			const stored = localStorage.getItem("r2explorer-no-spaces");
+			if (stored !== null) {
+				this.noSpacesInNames = stored === "true";
+			}
+		},
+		setNoSpacesSetting(value) {
+			this.noSpacesInNames = value;
+			localStorage.setItem("r2explorer-no-spaces", String(value));
 		},
 		async loadServerConfigs(router, q, handleError = false) {
 			// This is the initial requests to server, that also checks if user needs auth

--- a/packages/worker/src/modules/buckets/moveObject.ts
+++ b/packages/worker/src/modules/buckets/moveObject.ts
@@ -40,6 +40,11 @@ export class MoveObject extends OpenAPIRoute {
 		const oldKey = decodeURIComponent(escape(atob(data.body.oldKey)));
 		const newKey = decodeURIComponent(escape(atob(data.body.newKey)));
 
+		// Handle folder rename differently - folders end with /
+		if (oldKey.endsWith("/")) {
+			return await this.moveFolder(bucket, oldKey, newKey);
+		}
+
 		const object = await bucket.get(oldKey);
 
 		if (object === null) {
@@ -56,5 +61,47 @@ export class MoveObject extends OpenAPIRoute {
 		await bucket.delete(oldKey);
 
 		return resp;
+	}
+
+	private async moveFolder(bucket: R2Bucket, oldKey: string, newKey: string) {
+		// List all objects with the old prefix
+		const objects: R2Object[] = [];
+		let cursor: string | undefined;
+
+		do {
+			const list = await bucket.list({
+				prefix: oldKey,
+				cursor,
+			});
+			objects.push(...list.objects);
+			cursor = list.truncated ? list.cursor : undefined;
+		} while (cursor);
+
+		// Move each object to the new location
+		for (const obj of objects) {
+			const newObjKey = newKey + obj.key.slice(oldKey.length);
+			const objData = await bucket.get(obj.key);
+
+			if (objData) {
+				await bucket.put(newObjKey, objData.body, {
+					customMetadata: objData.customMetadata,
+					httpMetadata: objData.httpMetadata,
+				});
+			} else {
+				// Handle empty folder markers
+				await bucket.put(newObjKey, "");
+			}
+
+			await bucket.delete(obj.key);
+		}
+
+		// If no objects existed (empty folder), create the new folder marker
+		if (objects.length === 0) {
+			await bucket.put(newKey, "");
+			// Try to delete the old folder marker
+			await bucket.delete(oldKey);
+		}
+
+		return { success: true, moved: objects.length };
 	}
 }


### PR DESCRIPTION
## Summary
Implements multi-select bulk actions in the file browser, enforces file/folder naming rules, adds ZIP download for selected items (including folders), and supports folder rename/move on the backend. Also introduces a configurable setting to disallow spaces in names and persists it across sessions.

## Changes
- Client
  - FileBrowser.vue
    - Added bulk action: Download ZIP for selected items
    - Expanded bulk download to include contents of folders
    - Handles progress notification during ZIP creation
  - appUtils.js
    - Added downloadFilesAsZip(bucket, files, onProgress) to package files into a ZIP and trigger a download
    - Added ARCHIVE_MISSPELLINGS array and getRandomArchiveName() for fun archive names
  - DragAndDrop.vue
    - Introduced sanitizeName(name) to replace spaces with underscores when the setting is on
    - Sanitizes file and folder names during multi-file/folder uploads
  - CreateFolder.vue
    - Replaced simple required rule with folderNameRules() that also enforces spaces restriction when enabled
  - FileOptions.vue
    - Added validation to prevent spaces in names when the noSpacesInNames setting is active
  - SettingsPage.vue
    - New File Naming section with toggle: Disallow spaces in names
    - Explanatory text about behavior (uploads, renaming, etc.)
  - main-store.js
    - Added noSpacesInNames state (default true) and persistence/load helpers (localStorage key: r2explorer-no-spaces)
    - Exposes setNoSpacesSetting and loads the setting on startup
- Backend/Worker
  - moveObject.ts
    - Enhanced to treat folder moves specially: moves whole folder trees by prefix and handles empty folder markers
    - Ensures nested objects are relocated and old markers cleaned up

## Details
- ZIP download flow
  - When user selects items (including folders) and clicks Download ZIP, the app expands folders to enumerate contained files, then uses downloadFilesAsZip to fetch file data and assemble a ZIP in-memory via zipSync, finally triggering a browser download with a randomly misspelled ZIP name (e.g., quirky archive names).
  - Progress is surfaced via notifications (0-100%), and the final status shows the downloaded archive name.
- Naming rules
  - A global setting noSpacesInNames controls whether spaces are allowed in file and folder names.
  - When enabled, spaces are sanitized to underscores during uploads, renaming, and folder creation.
  - CreateFolder.vue and DragAndDrop.vue honor this setting; FileOptions.vue validates against spaces when appropriate.
  - SettingsPage.vue provides a UI to toggle this behavior and an explanation of its impact.
- Folder rename/move
  - The worker now supports moving folders by enumerating all objects under the old prefix and relocating them under the new prefix, preserving object data and metadata.
  - If an empty folder is moved or a folder marker exists, it preserves/creates the appropriate placeholders.

## Testing plan
- Global setting
  - Open Settings > File Naming and enable/disable Disallow spaces in names
  - Create folders and upload files with spaces; verify names are sanitized to underscores when enabled
  - Verify that renaming and folder creation respect the rule (errors shown in UI when invalid)
  - Validate persistence across reloads via localStorage key r2explorer-no-spaces
- Bulk ZIP download
  - In a bucket with a mix of files and folders, perform multi-select and click Download ZIP
  - Confirm a single ZIP file is downloaded (filename: random misspelled name, e.g. misspelling.zip)
  - Ensure progress updates are shown during ZIP creation
  - Ensure contents include nested files from folders
- Folder rename/move on backend
  - Trigger a bulk move/rename operation that targets a folder path
  - Verify all nested files are moved to the new path and old keys are deleted
  - Check behavior when moving an empty folder (marker handling)
- UI/UX checks
  - Ensure Bulk Download ZIP button is visible when items are selected
  - Confirm range/shift-click multi-select behavior remains intuitive with new bulk actions

## Migration / Notes
- No breaking API changes for existing users; new features are opt-in via UI and existing flows remain functional.
- The default noSpacesInNames is ON to align with safer naming by default.
- Local storage key for the setting is r2explorer-no-spaces. If you customize storage, you may want to migrate.

## Potential issues
- ZIP creation may be memory-intensive for very large folders; consider streaming or chunked ZIP in future iterations if needed.
- Folder rename logic assumes non-circular and readable object listings; extremely large folders may require pagination adjustments.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e0cbaff8-58dd-43a1-a20b-5c8005eba9d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements three main features for the R2 Explorer file browser:

### 1. Multi-Select Bulk ZIP Download
- Adds `downloadFilesAsZip()` utility in `appUtils.js` that fetches selected files, assembles an in-memory ZIP via `fflate`, and triggers download with a randomly generated misspelled archive name
- Implements `handleBulkDownloadZip()` in FileBrowser.vue to enumerate and expand folder selections into individual files, initiate ZIP creation, and display progress notifications (0–100%)
- Introduces archive naming utilities (`ARCHIVE_MISSPELLINGS`, `getRandomArchiveName()`)

### 2. File/Folder Naming Rules (Configurable)
- Introduces `noSpacesInNames` preference in main store (default: `true`) with localStorage persistence (key: `r2explorer-no-spaces`)
- Adds validation rules in CreateFolder.vue and FileOptions.vue to prevent spaces when enabled
- Implements `sanitizeName()` in DragAndDrop.vue to replace spaces with underscores during uploads and folder creation
- New "File Naming" settings card in SettingsPage.vue with toggle to control behavior
- Validation applied consistently across uploads, renames, and folder creation

### 3. Backend Folder Rename/Move
- New `moveFolder()` method in moveObject.ts handles entire folder trees by prefix-based listing and relocation
- Enumerates all objects under old prefix, moves each individually while maintaining metadata, creates empty folder markers when needed, and cleans up old objects
- Atomically handles empty folders and ensures consistency during tree operations

### Code Review Effort
- Frontend changes: Medium (7 files with validation, state management, and UI updates)
- Backend changes: High (complex prefix-based folder operations with edge cases for empty folders)

All changes are backward compatible with sensible defaults (no-spaces enabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->